### PR TITLE
Build.yml Update ; Conflict Change only Comment Field

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,9 @@ jobs:
         shell: pwsh
         run: |
           dotnet publish /p:Version=$env:CurrentVersion /p:FileVersion=$env:CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish" ".\Agent"
-          Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
+          Get-ChildItem -Path "./Agent/bin/publish/" | ForEach-Object { 
+              Compress-Archive -Path $_.FullName -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Update
+          }
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -170,7 +170,7 @@ jobs:
         
         
     - name: Download macOS x64 Agent
-    - uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v2
       with:
         name: Mac-Agent-x64
         path: ./Server/wwwroot/Content/Remotely-MacOS-x64.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,13 +101,7 @@ jobs:
       ServerUrl: ${{ github.event.inputs.serverUrl }}
 
     steps:
-
-    - uses: actions/download-artifact@v2
-      with:
-        name: Mac-Agent-x64
-        path: ./Server/wwwroot/Content/Remotely-MacOS-x64.zip
-
-        
+       
     - name: Checkout
       uses: actions/checkout@v2
       with:
@@ -173,6 +167,13 @@ jobs:
         echo "CurrentVersion=$CurrentVersion" >> $GITHUB_ENV
 
         Write-Host "Setting current version to $CurrentVersion."
+        
+        
+    - name: Download macOS x64 Agent
+    - uses: actions/download-artifact@v2
+      with:
+        name: Mac-Agent-x64
+        path: ./Server/wwwroot/Content/Remotely-MacOS-x64.zip
 
     # Run the Publish script to build clients and server.
     - name: Run Publish script

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,7 +173,7 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: Mac-Agent-x64
-        path: ./Server/wwwroot/Content/Remotely-MacOS-x64.zip
+        path: ./Server/wwwroot/Content/
 
     # Run the Publish script to build clients and server.
     - name: Run Publish script

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
 
       - name: Publish macOS x64 Agent
         shell: pwsh
+        env:
+          CurrentVersion: ${{ env.CurrentVersion }}
         run: |
           Write-Host "Publishing agent with version $env:CurrentVersion"
           dotnet publish /p:Version=$env:CurrentVersion /p:FileVersion=$env:CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install .NET Core
-        uses: actions/setup-dotnet@v1.7.2
+        uses: actions/setup-dotnet@v1.8.0
+        
+      - name: Setup NuGet.exe for use with actions
+        uses: NuGet/setup-nuget@v1.0.5
 
       - name: Set current version
         shell: pwsh
@@ -64,7 +67,8 @@ jobs:
       - name: Publish macOS x64 Agent
         shell: pwsh
         run: |
-          dotnet publish /p:Version=$env:CurrentVersion /p:FileVersion=$env:CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish" "./Agent"
+          Write-Host "Publishing agent with version $env:CurrentVersion"
+          dotnet publish /p:Version=$env:CurrentVersion /p:FileVersion=$env:CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
           Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
 
       - name: Upload build artifact
@@ -113,7 +117,7 @@ jobs:
         
     # Install the .NET Core workload
     - name: Install .NET Core
-      uses: actions/setup-dotnet@v1.7.2
+      uses: actions/setup-dotnet@v1.8.0
       
     # Add  MSBuild to the PATH: https://github.com/microsoft/setup-msbuild
     - name: Setup MSBuild.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,11 +66,9 @@ jobs:
 
       - name: Publish macOS x64 Agent
         shell: pwsh
-        env:
-          CurrentVersion: ${{ env.CurrentVersion }}
         run: |
           Write-Host "Publishing agent with version $env:CurrentVersion"
-          dotnet publish /p:Version=$env:CurrentVersion /p:FileVersion=$env:CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
+          dotnet publish /p:Version=${{ env.CurrentVersion }} /p:FileVersion=${{ env.CurrentVersion }} --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
           Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
 
       - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,13 +61,11 @@ jobs:
 
           Write-Host "Setting current version to $CurrentVersion."
 
-      - name: Set current version
+      - name: Publish macOS x64 Agent
         shell: pwsh
         run: |
-          dotnet publish /p:Version=$env:CurrentVersion /p:FileVersion=$env:CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish" ".\Agent"
-          Get-ChildItem -Path "./Agent/bin/publish/" | ForEach-Object { 
-              Compress-Archive -Path $_.FullName -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Update
-          }
+          dotnet publish /p:Version=$env:CurrentVersion /p:FileVersion=$env:CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish" "./Agent"
+          Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,8 +67,18 @@ jobs:
       - name: Publish macOS x64 Agent
         shell: pwsh
         run: |
-          Write-Host "Publishing agent with version ${{ env.CurrentVersion }}"
-          dotnet publish /p:Version=${{ env.CurrentVersion }} /p:FileVersion=${{ env.CurrentVersion }} --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
+          $VersionString = git show -s --format=%ci
+          $VersionDate = [DateTimeOffset]::Parse($VersionString)
+
+          $Year = $VersionDate.Year.ToString()
+          $Month = $VersionDate.Month.ToString().PadLeft(2, "0")
+          $Day = $VersionDate.Day.ToString().PadLeft(2, "0")
+          $Hour = $VersionDate.Hour.ToString().PadLeft(2, "0")
+          $Minute = $VersionDate.Minute.ToString().PadLeft(2, "0")
+          $CurrentVersion = "$Year.$Month.$Day.$Hour$Minute"
+          
+          Write-Host "Publishing agent with version $CurrentVersion"
+          dotnet publish /p:Version=$CurrentVersion /p:FileVersion=$CurrentVersion --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
           Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
 
       - name: Upload build artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Publish macOS x64 Agent
         shell: pwsh
         run: |
-          Write-Host "Publishing agent with version $env:CurrentVersion"
+          Write-Host "Publishing agent with version ${{ env.CurrentVersion }}"
           dotnet publish /p:Version=${{ env.CurrentVersion }} /p:FileVersion=${{ env.CurrentVersion }} --runtime osx-x64 --configuration Release --output "./Agent/bin/publish/" "./Agent/"
           Compress-Archive -Path "./Agent/bin/publish/*" -DestinationPath "./Agent/bin/Remotely-MacOS-x64.zip" -Force
 


### PR DESCRIPTION
Change should be Commented out Repo only; proceeding with master branch.
---

Thank you for your contribution to the Remotely project.  It is required that contributors assign copyright to me (Jared Goodwin) so that I retain full ownership of the project.

This makes it easier for other entities to use the software because they only have to deal with one copyright holder.  It also gives me assurance that I'll be able to make decisions in the future without gathering and consulting all contributors.

While this may seem odd, many open source maintainers practice this.  Here are a couple well-known examples:

- Free Software Foundation: http://www.gnu.org/licenses/why-assign.html
- Microsoft: https://cla.opensource.microsoft.com/

A nice article on the topic can be found here:  https://haacked.com/archive/2006/01/26/WhoOwnstheCopyrightforAnOpenSourceProject.aspx/

By submitting this PR, you agree to the following:

> You hereby assign copyright in this PR's code to the Remotely project and its copyright holder, Jared Goodwin, to be licensed under the same terms as the rest of the code.  You agree to relinquish any and all copyright interest in the software, to the detriment of your heirs and successors.
